### PR TITLE
Improve reverse of string.

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -27,12 +27,12 @@ bool isNotEmpty(String s) => s != null && s.isNotEmpty;
 /// Returns a string with characters from the given [s] in reverse order.
 String reverse(String s) {
   if (s == null || s == '') return s;
-  StringBuffer sb = new StringBuffer();
-  var runes = s.runes;
-  for (int i = runes.length - 1; i >= 0; i--) {
-    sb.writeCharCode(runes.elementAt(i));
+  var buffer = new StringBuffer();
+  var iterator = s.runes.iterator..reset(s.length);
+  while (iterator.movePrevious()) {
+    buffer.writeCharCode(iterator.current);
   }
-  return sb.toString();
+  return buffer.toString();
 }
 
 /// Returns a string with characters from the given [s] in reverse order.


### PR DESCRIPTION
The existing implementation of `reverse` was quadratic in the string length.

It's still a very problematic method because it doesn't understand Unicode characters, only code points, so it will mis-attribute combining marks in a reversed string, e.g., `reverse("niño")` would become `"õnin"`.